### PR TITLE
Bump requests version to 2.25.1 to be compatible with urllib3

### DIFF
--- a/te/te_docker/requirements.txt
+++ b/te/te_docker/requirements.txt
@@ -42,7 +42,7 @@ psycopg2==2.7.7
 psycopg2-binary==2.8.2
 redis==3.0.1
 redis-queue==0.5
-requests==2.21.0
+requests==2.25.1
 rq==0.13.0
 ssh2-python==0.17.0
 sysv-ipc==1.0.0

--- a/te/tedp_docker/requirements.txt
+++ b/te/tedp_docker/requirements.txt
@@ -31,7 +31,7 @@
 
 greenlet==0.4.15
 redis==3.1.0
-requests==2.21.0
+requests==2.25.1
 rq==0.13.0
 sysv-ipc==1.0.0
 urllib3==1.26.5


### PR DESCRIPTION
While building the TENS with changes of @sanathpholla, the build had complained about the  incompatibility of urllib3 and requests python library. 

Bumping it to 2.25.1 solved the issue