### PR TITLE
Fix for log rotation not happening in te and te_dp

### DIFF
--- a/te/te_docker/Dockerfile
+++ b/te/te_docker/Dockerfile
@@ -64,10 +64,11 @@ RUN apt-get update && \
     rm grafana_7.0.1_amd64.deb
 
 RUN echo "/tmp/*.log { \n\
-size 256M \n\
-rotate 2 \n\
+su root root \n\
+size 100M \n\
+rotate 5 \n\
 compress \n\
-delaycompress \n\
+copytruncate \n\
 missingok \n\
 }\n" > /etc/logrotate.d/te-logs
 RUN chmod 0644 /etc/logrotate.d/te-logs

--- a/te/tedp_docker/Dockerfile
+++ b/te/tedp_docker/Dockerfile
@@ -74,17 +74,19 @@ RUN mkdir /tmp/ramcache && chmod -R 755 /tmp/ramcache
 
 # logrotate for csv of process in ramcache and log files in /tmp/
 RUN echo "/tmp/ramcache/*.csv { \n\
+su root root \n\
 size 5M \n\
-rotate 2 \n\
+rotate 5 \n\
 compress \n\
-delaycompress \n\
+copytruncate \n\
 missingok \n\
 }\n\
 /tmp/*.log { \n\
-size 256M \n\
-rotate 2 \n\
+su root root \n\
+size 100M \n\
+rotate 5 \n\
 compress \n\
-delaycompress \n\
+copytruncate \n\
 missingok \n\
 }\n" > /etc/logrotate.d/te-logs && chmod 0644 /etc/logrotate.d/te-logs
 


### PR DESCRIPTION
Fixing https://github.com/vmware/te-ns/issues/36

* Log rotation on te and te_dp was failing due to file permission issue.(Similar to issue mentioned in this here - https://stackoverflow.com/questions/26482773/apache-and-logrotate-configuration)
```
root@Client-te-1:/tmp# /usr/sbin/logrotate -d /etc/logrotate.d/te-logs

considering log /tmp/TE-stderr---supervisor-Feijhk.log
error: skipping "/tmp/TE-stderr---supervisor-Feijhk.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
```
* Fix for the above issue is to add `su <user> <group>` for each folder in log rotate config. In all the cases, it was root and root(`su root root`).

* copytruncate option added to log rotation config and delaycompress deleted.
* Size is reduced to 100M wherever earlier it was 256M
* Total rotate count is increased from 2 to 5
