### PR TITLE
Add the option to abort data tranfer after connection setup for a CPS…

### DIFF
--- a/RESOURCE_CONFIGURATION.md
+++ b/RESOURCE_CONFIGURATION.md
@@ -46,6 +46,7 @@
 * **default-get-post-ratio** : The value specifies ratio at which the target vip must be targetted with GETs and POSTs. This value is used only if nothing is specified at the vip level. If one has to specify the ratio at vip level it must be specified using the key `get-post-profile`(Optional)
 
 * **send-tcp-resets** : Boolean specifying if the client must send RST instead of FIN, where ever applicable
+* **tcp-connect-only** : Boolean specifying if the request transfer should be skipped. Connection reuse is disabled for this case. Hence cycle-type resume is unsupported if this option is enabled.
 
 * **tcp-keepalive-timeout** : Value is seconds specifying the intervals at which TCP keep alive has to be sent. This value must be ideally be less than the TCP timeout at the server end.
   * Defaults to 20s.
@@ -104,6 +105,7 @@
 
     "tcp-keepalive-timeout" : 15,
     "send-tcp-resets"       : false,
+    "tcp-connect-only" : false,
 
     "default-get-post-ratio" : "1:1",
     "get-profiles" : {

--- a/te/TE_WORK.py
+++ b/te/TE_WORK.py
@@ -436,6 +436,8 @@ def start_te_dp(resource_config=None, session_config=None, resource_hash=None, s
         if 'send-tcp-resets' in resconv_sort['resource-config']:
             resconv_new['send-tcp-resets']=resconv_sort['resource-config']['send-tcp-resets']
 
+        if 'tcp-connect-only' in resconv_sort['resource-config']:
+            resconv_new['tcp-connect-only']=resconv_sort['resource-config']['tcp-connect-only']
         """
         # Unsupported knobs as of today
         # Lot of the knobs can be used to simulate attacks

--- a/te/te_swagger.json
+++ b/te/te_swagger.json
@@ -493,6 +493,12 @@
                         "type": "boolean",
                         "format": "boolean"
                     },
+                    "tcp-connect-only": {
+                        "title": "Set to true if the request transfer should be skipped",
+                        "description" : "TCP CLIENT ONLY",
+                        "type": "boolean",
+                        "format": "boolean"
+                    },
                     "default-get-post-ratio": {
                         "title": "The ratio at which vip will be targeted with gets and posts",
                         "description" : "TCP CLIENT ONLY",

--- a/te_dp/src/te_agent.c
+++ b/te_dp/src/te_agent.c
@@ -1006,6 +1006,7 @@ void te_process_resource_config(const char* resource_config, bool is_update) {
         //TCP Defaults
         res_cfg_temp->send_tcp_resets = false;
         res_cfg_temp->tcp_keepalive_timeout = 20;
+        res_cfg_temp->tcp_connect_only = false;
 
         //Basic INIT
         te_http_url_metrics_t** url_get_metrics_profile = NULL;
@@ -1253,7 +1254,7 @@ void te_process_resource_config(const char* resource_config, bool is_update) {
                 }
 
                 //TCP Params
-                if (strstr(key,"send-tcp-reset")) {
+                if (strstr(key,"send-tcp-resets")) {
                     if (json_object_get_boolean(jvalue)) {
                         res_cfg_temp->send_tcp_resets = true;
                     }
@@ -1266,6 +1267,14 @@ void te_process_resource_config(const char* resource_config, bool is_update) {
                 }
                 if(strstr(key, "tcp-connect-timeout")) {
                     res_cfg_temp->tcp_connect_timeout = json_object_get_int(jvalue);
+                }
+                if (strstr(key,"tcp-connect-only")) {
+                    if (json_object_get_boolean(jvalue)) {
+                        res_cfg_temp->tcp_connect_only = true;
+                    }
+                    else {
+                        res_cfg_temp->tcp_connect_only = false;
+                    }
                 }
 
                 //HTTP VERSION AND PIPELINE

--- a/te_dp/src/te_dp.h
+++ b/te_dp/src/te_dp.h
@@ -766,6 +766,7 @@ typedef struct te_resource_config_s {
     //TCP (or) CURL Params
     bool is_verbose;
     bool send_tcp_resets;       //To enable TE to send tcp resets
+    bool tcp_connect_only;       //Establish a connection and exit
     int tcp_keepalive_timeout;  //To send a keep-alive to server
     int tcp_connect_timeout;
 

--- a/te_dp/src/te_tcp_dp.c
+++ b/te_dp/src/te_tcp_dp.c
@@ -1140,6 +1140,12 @@ void te_set_curl_opts(CURL *handle, te_session_config_t *session_cfg_p, te_sessi
         if(unlikely(CEcode != CURLE_OK))
             eprint("CURLOPT_SOCKOPTFUNCTION, %d, %s\n",(int)CEcode, curl_easy_strerror(CEcode));
     }
+    //Perform connection setup and exit without data transfer
+    if (res_cfg->tcp_connect_only) {
+        CEcode = curl_easy_setopt(handle, CURLOPT_CONNECT_ONLY, 1L);
+        if(unlikely(CEcode != CURLE_OK))
+            eprint("CURLOPT_CONNECT_ONLY, %d, %s\n",(int)CEcode, curl_easy_strerror(CEcode));
+    }
 
     //Call Back to Close the socket connection
     CEcode = curl_easy_setopt(handle, CURLOPT_CLOSESOCKETFUNCTION, te_socket_close);


### PR DESCRIPTION
… test

Update te_agent for send-tcp-resets
Signed-off-by: Vipin P R <vipinp@vmware.com>


This change set introduces a knob via libcurl to perform connection setup and skip the data transfer. 
With this option set, cycle-type : resume is a no-op. 

libcurl offers a rich set of APIs for HTTP(S) requests. Ideally for an L4 CPS test, we could bypass these and maintain an internal pool of connections [reuse -- for num open connections, no-reuse / reopen -- for CPS]. 
We could leverage our internal socket table for the same. Doing so should eliminate a lot of additional overhead as there are HTTP/SSL options which are not required if we do a L4 CPS test. 

		Advantages :
			1. more control at a TCP connection level
			2. possibly better performance if we do it right
		Disadvantage :
			1. More operational overhead in maintaining it

Of course, this would need some changes to existing mechanism in terms of how we fire up requests. 
cc. @aravindhank11 

Will be revisited at a later phase. 
