### PR TITLE
start cron during docker startup for te docker

### DIFF
--- a/te/te_docker/Dockerfile
+++ b/te/te_docker/Dockerfile
@@ -74,7 +74,7 @@ missingok \n\
 }\n" > /etc/logrotate.d/te-logs
 RUN chmod 0644 /etc/logrotate.d/te-logs
 
-#Creating a cron (Running cron job every 15 mins -- logrotate)
+#Creating a cron (Running cron job every 2 mins -- logrotate)
 RUN echo "*/2 * * * * /usr/sbin/logrotate /etc/logrotate.d/te-logs" > /etc/cron.d/cron_logrotate_te_logs
 RUN chmod 0644 /etc/cron.d/cron_logrotate_te_logs
 RUN crontab /etc/cron.d/cron_logrotate_te_logs
@@ -121,6 +121,7 @@ ENTRYPOINT sed -i "s/5001/$NGINX_PORT/g" /etc/nginx/sites-available/default && \
     redis-server --port $REDIS_PORT --daemonize yes && /etc/init.d/nginx restart && \
     sed -i "s/5432/$POSTGRES_PORT/g" /etc/postgresql/*/main/postgresql.conf && \
     service postgresql restart && \
+    service cron start && \
     sed -i "s/url: localhost:[0-9]*/url: localhost:$POSTGRES_PORT/g" /etc/grafana/provisioning/datasources/postgres_grafana_config.yaml && \
     echo "[supervisord]" >> /etc/supervisord.conf && \
     echo "nodaemon=true" >> /etc/supervisord.conf && \

--- a/te/tedp_docker/Dockerfile
+++ b/te/tedp_docker/Dockerfile
@@ -90,7 +90,7 @@ copytruncate \n\
 missingok \n\
 }\n" > /etc/logrotate.d/te-logs && chmod 0644 /etc/logrotate.d/te-logs
 
-# cron job every 15 mins -- logrotate
+# cron job every 2 mins -- logrotate
 RUN echo "*/2 * * * * /usr/sbin/logrotate /etc/logrotate.d/te-logs" > /etc/cron.d/cron_logrotate_te_logs && \
     chmod 0644 /etc/cron.d/cron_logrotate_te_logs && crontab /etc/cron.d/cron_logrotate_te_logs
 


### PR DESCRIPTION
Cron was not started during startup of te docker.
Added cron start for te docker. Such that cron service is started and logrotate can be run using cron
```
root@sanath-dev:/home/aviuser/workspace/avi-dev# docker logs a09b2607003a
 * Restarting nginx nginx                                                [ OK ]
 * Restarting PostgreSQL 11 database server                              [ OK ]
 * Starting periodic command scheduler cron                              [ OK ]

root@sanath-dev:/# service cron status
 * cron is running

root@sanath-dev:/# ps aux | grep cron
root        99  0.0  0.0  27768  2644 ?        Ss   08:16   0:00 /usr/sbin/cron
```