### PR TITLE
Revert "Bump numpy from 1.18.1 to 1.22.0 in /te/te_docker"

### DIFF
--- a/te/te_docker/requirements.txt
+++ b/te/te_docker/requirements.txt
@@ -48,7 +48,7 @@ ssh2-python==0.17.0
 sysv-ipc==1.0.0
 urllib3==1.26.5
 jsonpickle==0.9.4
-numpy==1.22.0
+numpy==1.18.1
 zmq==0.0.0
 aiozmq==0.7.1
 asyncio==3.4.3


### PR DESCRIPTION
Reverts vmware/te-ns#50