### PR TITLE
Adding exit code 127: python module not found

### DIFF
--- a/te/TE.py
+++ b/te/TE.py
@@ -1098,11 +1098,12 @@ class FlaskApplicationWrapper:
                 17 : "Unable o get free ports",
                 18 : "Wrong parameters passed",
                 19 : "Unable to calculate checksum of Tar file",
-                20  : "Unable to find free port even after several tries",
-                21  : "Unable to find netstat command",
-                22  : "Unable to find both systemctl and service commands",
+                20 : "Unable to find free port even after several tries",
+                21 : "Unable to find netstat command",
+                22 : "Unable to find both systemctl and service commands",
                 23 : "docker pull command failed",
                 24 : "docker run command failed",
+                127 : "python module not found",
                 200 : "Success",
                 404 : "Fatal: unknown reason"
         }

--- a/te/TE_WRAP.py
+++ b/te/TE_WRAP.py
@@ -252,11 +252,12 @@ class TensTE():
                 17 : "Unable to get free ports",
                 18 : "Wrong parameters passed",
                 19 : "Unable to calculate the checksum of Tar File",
-                20  : "Unable to find free port even after several tries",
-                21  : "Unable to find netstat command",
-                22  : "Unable to find both systemctl and service commands",
+                20 : "Unable to find free port even after several tries",
+                21 : "Unable to find netstat command",
+                22 : "Unable to find both systemctl and service commands",
                 23 : "docker pull command failed",
                 24 : "docker run command failed",
+                127 : "python module not found",
                 200 : "Success",
                 404 : "Fatal: unknown reason"
         }


### PR DESCRIPTION
TE is both python2 and python3 complaint, however we issue `python` command when setting up te/tedp docker.
If python3 or python2 is installed but `python` does not have reference to any of these version - it would result in failure to setup te/tedp.

**To solve this:-**  
Add a symlink to `python3` or `python2` to `python`
```
ln -s  /usr/bin/python3 /usr/bin/python
```


Signed-off-by: priyadarshitathagat <tpriyadarshi@vmware.com>