### PR TITLE
TENS support for UDP V6 traffic

### DIFF
--- a/te_dp/src/te_agent.h
+++ b/te_dp/src/te_agent.h
@@ -78,4 +78,7 @@ void te_push_session_config_fsm(TE_SESSION_CONFIG_STATE state);
 void session_config_uv_async(uv_async_t *req);
 void te_tedp_poll_uv_cb(uv_poll_t *req, int status, int events);
 
+extern int validate_ipv6_address(char ip_str[]);
+extern int validate_ipv4_address(char ip_str[]);
+
 #endif

--- a/te_dp/src/te_sock.h
+++ b/te_dp/src/te_sock.h
@@ -78,7 +78,8 @@ typedef struct te_udp_server_sock_state_s {
     unsigned long          timeout;
     // dg sent and rcvd timestamp -- to calculate latency from the server perspective
     double                 first_dg_rcvd_ts;
-    unsigned long          vip, client_ip;
+    unsigned long          client_ip;
+    char                   vip[40];
     unsigned short         vport, client_port;
 } te_udp_server_sock_state_t;
 
@@ -98,6 +99,7 @@ typedef struct te_socket_node_s {
     // Note that the remote_sock_addr's ip and port need not be same as client_ip and client_port
     // The IP and Port in remote_sock_addr can denote the Application's src port and ip
     struct sockaddr_in            remote_sock_addr;
+    struct sockaddr_in6            remote_sock_addr_v6;
     unsigned int                  client_ip;
     unsigned short                client_port;
 
@@ -123,6 +125,8 @@ typedef struct te_socket_hashTbl_s {
 
 te_socket_node_t* te_create_or_retrieve_tcp_socket(curl_socket_t, te_session_t*);
 te_socket_node_t* te_create_or_retrieve_udp_server_socket(struct sockaddr_in, unsigned int, \
+    unsigned short, unsigned long, udp_server_easy_handle_t *);
+te_socket_node_t* te_create_or_retrieve_udp_server_socket_v6(struct sockaddr_in6, unsigned int, \
     unsigned short, unsigned long, udp_server_easy_handle_t *);
 void te_udp_sock_parse_on_timeout(double);
 void te_remove_udp_server_socket_node(te_socket_node_t*);

--- a/te_dp/src/te_udp_lib.h
+++ b/te_dp/src/te_udp_lib.h
@@ -159,7 +159,8 @@ typedef struct __attribute__ ((__packed__)) udp_message_header_s {
     unsigned int   response_size_dg;   //Size of each dg in response
     unsigned short response_num_dg;    //Number of dg to respond
     unsigned long  timeout;            //Timeout to stop listening
-    unsigned int   vip, client_ip;     //vip can be different from the target server ip
+    char           vip[40];            //vip can be different from the target server ip
+    unsigned int   client_ip;
     unsigned short vport, client_port; // similarly vport can be different from server port
 
     // vip and vport are added in order to collect metric at the back end server w.r.t to the vip
@@ -171,14 +172,16 @@ typedef struct udp_server_easy_handle_s {
     unsigned short      d_port;
     //UDP's listening address
     struct sockaddr_in  recv_addr;
+    struct sockaddr_in6  recv_addr_v6;
     //uv_udp's listening handle
     uv_udp_t            uv_udp_handle;
+    uv_udp_t            uv_udp6_handle;
     //User pointer to be passed along with the callbacks
     void*               usr_ptr;
     //User callback function pointer for send callback
-    void (*user_send_callback_fptr)(unsigned long, unsigned short, udp_send_metrics_t, void*);
+    void (*user_send_callback_fptr)(char *, unsigned short, udp_send_metrics_t, void*);
     //User callback function pointer for recv callback
-    void (*user_recv_callback_fptr)(unsigned long, unsigned short, udp_recv_metrics_t, void*);
+    void (*user_recv_callback_fptr)(char *, unsigned short, udp_recv_metrics_t, void*);
 } udp_server_easy_handle_t;
 
 // We have a global timer which will kick in when there is at least one listener
@@ -270,6 +273,7 @@ typedef struct udp_multi_handle_s {
     unsigned short   port;
     //Combination of str_ip:port of remote address
     struct sockaddr_in *remote_sock_addr;
+    struct sockaddr_in6 *remote_sock_addr_v6;
 
     //User callback function pointer for send callback
     void (*user_send_callback_fptr)(udp_send_metrics_t, void*);


### PR DESCRIPTION
Changes have been made to support V6 UDP traffic :-

**Config Used:-**
```
{'resource_config': {'res0': {'default-download-upload-ratio': '0:1',
   'udp-profiles': {'profile-1': {'upload': {'request': {'num-datagram-range': [10,
        10],
       'datagram-size-range': [10, 10]},
      'response': {'num-datagram-range': [10, 10]}}}},
   'vip-selection-rr': True,
   'vip-list': [{'vip': '[2402:740:0:494::359]:5432',
     'udp-profile': 'profile-1'}]},
  'udp': {'type': 'server', 'port-list': [5432]}},
 'session_config': {'ses': {'session-type': 'Browser',
   'num-sessions': 1,
   'connection-range': [2, 2],
   'requests-range': [2, 2],
   'cycle-type': 'resume',
   'num-cycles': 1}},
 'te_dp_dict': {'100.65.10.8': {'instance_profile': {'tedp_inst0': 1},
   'user': 'root',
   'passwd': 'avi123'},
  '100.65.10.9': {'instance_profile': {'udp-server-profile': 1},
   'user': 'root',
   'passwd': 'avi123'}},
 'start_time': '2023-02-15 13:41:38',
 'instanceProfileConfig': {'tedp_inst0': {'res-tag': 'res0',
   'ses-tag': 'ses',
   'traffic-profile': 'UDP'},
  'udp-server-profile': {'res-tag': 'udp',
   'traffic-mode': 'SERVER',
   'traffic-profile': 'UDP'}}}

```


**Results:-**
```
get_vip_metrics('TOTAL', traffic_profile='UDP', traffic_mode='CLIENT')

{'status': True,
 'statusmessage': {'vip=100.66.148.63:5432': {'cps': 724.6533333333333,
   'dg_recd': 0.0,
   'dg_recv_timedout': 0.0,
   'dg_send_fail': 0.0,
   'dg_sent': 1086980.0,
   'dg_size_recd': 0.0,
   'dg_size_sent': 10869800.0,
   'dps': 14493.066666666668,
   'failed_connections': 0.0,
   'good_connections': 54349.0,
   'latency_max': 0.0,
   'latency_min': nan,
   'reqs_failed': 0.0,
   'reqs_sent': 108698.0,
   'resp_rcvd': 0.0,
   'resp_timedout': 0.0,
   'rps': 0.0,
   'sessions': 54348.0,
   'tput': 144930.66666666666,
   'var_latency': 0.0},
  'vip=2402:740:0:494::359:5432': {'cps': 720.4128329297821,
   'dg_recd': 0.0,
   'dg_recv_timedout': 0.0,
   'dg_send_fail': 0.0,
   'dg_sent': 11901210.0,
   'dg_size_recd': 0.0,
   'dg_size_sent': 119012100.0,
   'dps': 14408.244552058111,
   'failed_connections': 0.0,
   'good_connections': 595061.0,
   'latency_max': 0.0,
   'latency_min': nan,
   'reqs_failed': 0.0,
   'reqs_sent': 1190121.0,
   'resp_rcvd': 0.0,
   'resp_timedout': 0.0,
   'rps': 0.0,
   'sessions': 595059.0,
   'tput': 144082.44552058112,
   'var_latency': 0.0}}}
```