### PR TITLE
openssl1.1.1 custom build with libcurl

### DIFF
--- a/te/tedp_docker/Dockerfile
+++ b/te/tedp_docker/Dockerfile
@@ -111,9 +111,11 @@ ADD te/TE_UTILS.py \
 # copy binary and library from previous stage
 RUN mkdir -pv $WORKDR/bin
 COPY --from=tedp_bin:v2.0 $WORKDR/bin $WORKDR/bin
+COPY --from=tedp_bin:v2.0 $WORKDR/usr_lib_deps.tar.gz ${usr_lib_path}/usr_lib_deps.tar.gz
 COPY --from=tedp_bin:v2.0 $WORKDR/usr_lib64_deps.tar.gz ${usr_lib64_path}/usr_lib64_deps.tar.gz
 COPY --from=tedp_bin:v2.0 $WORKDR/lib64_deps.tar.gz ${lib64_path}/lib64_deps.tar.gz
-RUN tar -xvf ${usr_lib64_path}/usr_lib64_deps.tar.gz -C / && rm ${usr_lib64_path}/usr_lib64_deps.tar.gz && \
+RUN tar -xvf ${usr_lib_path}/usr_lib_deps.tar.gz -C / && rm ${usr_lib_path}/usr_lib_deps.tar.gz && \
+    tar -xvf ${usr_lib64_path}/usr_lib64_deps.tar.gz -C / && rm ${usr_lib64_path}/usr_lib64_deps.tar.gz && \
     tar -xvf ${lib64_path}/lib64_deps.tar.gz -C / && rm ${lib64_path}/lib64_deps.tar.gz && \
     ldconfig -v
 

--- a/te/tedp_docker/tedp_bin_builder.dockerfile
+++ b/te/tedp_docker/tedp_bin_builder.dockerfile
@@ -51,17 +51,58 @@ RUN apt install libjson-c-dev -y
 RUN apt build-dep curl -y
 RUN apt install wget -y
 RUN apt install build-essential nghttp2 libnghttp2-dev -y
-RUN apt install -y curl && apt install -y libcurl4-openssl-dev
-RUN apt install -y openssl && apt install -y libssl-dev
+
+
+##########################################################
+#  Purging openssl
+RUN apt remove --purge -y libssl-dev libssl-doc openssl
+
+# Custom install openssl 1.1.1
+RUN cd /tmp \
+    && wget --no-check-certificate https://www.openssl.org/source/openssl-1.1.1n.tar.gz \
+    && tar -xzvf openssl-1.1.1n.tar.gz \
+    && cd openssl-1.1.1n \
+    && ./config --prefix=/usr/local --openssldir=/usr/local/ssl \
+    && make -j$(nproc) && make install \
+    && cd /tmp \
+    && rm -rf openssl-1.1.1* \
+    && ldconfig
+
+# Install Zlib
+RUN cd /tmp \
+    && wget --no-check-certificate https://zlib.net/zlib-1.2.13.tar.gz \
+    && tar -xzvf zlib-1.2.13.tar.gz \
+    && cd zlib-1.2.13 \
+    && ./configure --prefix=/usr/local \
+    && make -j$(nproc) && make install \
+    && cd /tmp \
+    && rm -rf zlib-1.2.13* \
+    && ldconfig
+
+# Install curl-7.83
+RUN cd /tmp \
+    && wget --no-check-certificate https://curl.se/download/curl-7.83.0.tar.gz \
+    && tar -xzvf curl-7.83.0.tar.gz \
+    && cd curl-7.83.0 \
+    && ./configure --prefix /usr/local --with-openssl=/usr/local --with-zlib=/usr/local --enable-ipv6 --with-nghttp2 \
+    && make -j$(nproc) && make install \
+    && cd /tmp \
+    && rm -rf curl-7.83.0* \
+    && ldconfig
+
 RUN apt install -y libuv1-dev
 RUN apt install -y libzmq3-dev
-RUN apt -y install libcrypto++-dev
 
 RUN mkdir -pv $WORKDR/bin && mkdir $WORKDR/obj
 ADD te_dp/Makefile $WORKDR
 ADD te_dp/src $WORKDR/src
 RUN cd $WORKDR && make all
 
+RUN tar -czf $WORKDR/usr_lib_deps.tar.gz \
+    ${usr_lib_path}/libcurl.so* \
+    ${usr_lib_path}/libssl.so.1* \
+    ${usr_lib_path}/libz.so* \
+    ${usr_lib_path}/libcrypto.so.1*
 
 RUN tar -czf $WORKDR/usr_lib64_deps.tar.gz \
     ${usr_lib64_path}/*
@@ -69,6 +110,4 @@ RUN tar -czf $WORKDR/usr_lib64_deps.tar.gz \
 RUN tar -czf $WORKDR/lib64_deps.tar.gz \
     ${lib64_path}/libjson-c.so.5* \
     ${lib64_path}/libuv.so.1* \
-    ${lib64_path}/libssl.so.3* \
-    ${lib64_path}/libzmq.so* \
-    ${lib64_path}/libcrypto.so.3*
+    ${lib64_path}/libzmq.so*

--- a/te_dp/Makefile
+++ b/te_dp/Makefile
@@ -39,7 +39,7 @@ BINDIR = bin
 DP_SRC   = $(wildcard $(SRCDIR)/*.c)
 DP_OBJ   = $(DP_SRC:$(SRCDIR)/%.c=$(OBJDIR)/%.o)
 DP_BIN   = $(BINDIR)/te_dp
-DP_FLAGS = -lcurl -luv -ljson-c -lssl -lpthread
+DP_FLAGS = -lcurl -luv -ljson-c -lssl -lcrypto -lpthread
 
 STAT_SRC   = $(wildcard $(SRCDIR)/*.cpp)
 STAT_OBJ   = $(STAT_SRC:$(SRCDIR)/%.cpp=$(OBJDIR)/%.o)


### PR DESCRIPTION
Issues with openssl3.0.2 performance
 [Massive performance degradation in OpenSsl 3.0 if used in a heavy multi threaded server application · Issue #17064 · openssl/openssl](https://github.com/openssl/openssl/issues/17064) 

We had to custom build openssl1.1.1 with libcurl, this brought back the perf numbers with the clients.

This is only a temporary fix, until we have a better fix and test done 3.0.2.
